### PR TITLE
add missing space

### DIFF
--- a/_i18n/de.yml
+++ b/_i18n/de.yml
@@ -28,7 +28,7 @@ pages:
   index_info2Title: Personalisierte Tafeln
   index_info3Title: 33 Sprachen
   index_info1Desc: "Cboard funktioniert mit modernen Browsern und ist auf einer Vielzahl von Plattformen verfügbar, darunter Desktops, Tablets und Mobiltelefone. Die Offline-Unterstützung ist in Google Chrome (Desktop & Android) verfügbar."
-  index_info2Desc: 'Mit mehr als 3400 Symbolen aus dem <a href="https://mulberrysymbols.org/">Mulberry Symbol Set</a>können Sie Ihre eigenen benutzerdefinierten Boards für verschiedene Lebenssituationen erstellen.'
+  index_info2Desc: 'Mit mehr als 3400 Symbolen aus dem <a href="https://mulberrysymbols.org/">Mulberry Symbol Set</a> können Sie Ihre eigenen benutzerdefinierten Boards für verschiedene Lebenssituationen erstellen.'
   index_info3Desc: "Cboard wird mit 33 Sprachen unterstützt. Die Unterstützung variiert je nach Betriebssystem."
   index_bottomTitle: 'Begleiten Sie uns auf GitHub'
   index_bottomDesc: 'Cboard ist ein Open-Source-Projekt. Wir freuen uns immer über eine helfende Hand. Wenn Sie etwas beitragen möchten, werden Sie zu unserem GitHub-Repo eingeladen.'


### PR DESCRIPTION
Found a missing whitespace after the link to _Mulberry Symbol Set_

ref: https://www.cboard.io/de/